### PR TITLE
feat: use docker with compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim-buster
+
+WORKDIR /bot
+
+RUN pip install poetry
+
+RUN apt update && apt install git -y && apt clean
+
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry install --no-root --no-dev
+
+COPY . .
+
+ENTRYPOINT ["poetry", "run", "python3"]
+CMD ["-m", "ezar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  bot:
+    container_name: ezar
+    env_file: .env
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
Use docker with docker-compose for a clean, reproducible environment

## The dockerfile steps
`FROM python:3.10-slim-buster` - base image
`WORKDIR /bot` - container directory
`RUN pip install poetry` - install poetry
`RUN apt update && apt install git -y && apt clean` - install git and clean after, disnake git dep
`COPY pyproject.toml poetry.lock ./` - step to copy poetry dep files, so poetry install will not run if they do not change
`RUN poetry install --no-root --no-dev` - install prod deps
`COPY . .` - copy all other files
`ENTRYPOINT ["poetry", "run", "python3"]` - will not be overwritten by `docker run`
`CMD ["-m", "ezar"]` - actual module, can be overwritten by `docker run`

## The docker compose file
`version: "3"` - docker compose yml version 3
`services:` - the base header for docker containers
`  bot:` - the bot's service
`    container_name: ezar` - the container name for docker
`    env_file: .env` - all env vars will be loaded from here (no need for `python-dotenv`)
`    restart: unless-stopped` - will start on machine restart, failure (reasonable attempt count) but not on `docker-compose down`/`Ctrl + C`
`    build:` - what is used when `--build` is specified
`      context: .` - where `docker build` is ran by compose
`      dockerfile: Dockerfile` - path to dockerfile

## Running
(Install docker + docker-compose, `apt install docker docker-compose -y` for example)

```bash
docker-compose up  # run without code changes
docker-compose up -d  # run without code changes, and it will be detached from this session
docker-compose up --build  # run, build dockerfile and add new code changes
docker-compose up --build  # use this one ideally, does both of the above, (building is cached by `Dockerfile` line so itll be near instant on code changes)
```
