### PR TITLE
fix(cogs): actually resolve application commands

### DIFF
--- a/ezar/cogs/listeners.py
+++ b/ezar/cogs/listeners.py
@@ -35,10 +35,12 @@ class Listeners(Cog):
         error_embed = Embeb(description=desc, failure=True)
 
         if isinstance(itr, Context):
-            log.error(f"Error with command {itr.command.qualified_name}: {exc}")
+            command_name = itr.command.qualified_name if itr.command else "None"
+            log.error(f"Error with command {command_name}: {exc}")
             return await itr.reply(embed=error_embed)
         else:
-            log.error(f"Error with slash command {itr.command.qualified_name}: {exc}")
+            command_name = itr.application_command.qualified_name
+            log.error(f"Error with slash command {command_name}: {exc}")
             return await itr.send(embed=error_embed)
 
 


### PR DESCRIPTION
Context commands - it may be `None` if this is a `CommandNotFound` exception
Application commands - `CommandInter.command` does not exist, but `CommandInter.application_command` does